### PR TITLE
Support passing arguments to the parser.

### DIFF
--- a/results.go
+++ b/results.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 type result struct {
@@ -133,7 +134,8 @@ func runParser(tomlFile string) (*bytes.Buffer, *bytes.Buffer, error) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 
-	c := exec.Command(parserCmd)
+	cmd := strings.Split(parserCmd, " ")
+	c := exec.Command(cmd[0], cmd[1:]...)
 	c.Stdin = f
 	c.Stdout = stdout
 	c.Stderr = stderr


### PR DESCRIPTION
Allow the parser to have default behavior other than to run the test suite.
