### PR TITLE
Add topl (Node.js/Browser) lib to list of decoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ note the commit SHA1 or version tag that your parser supports in your `README`.
 * C++ (@skystrife) - https://github.com/skystrife/cpptoml
 * Go (@thompelletier) - https://github.com/pelletier/go-toml
 * Go w/ Reflection (@BurntSushi) - https://github.com/BurntSushi/toml/tree/master/cmd/toml-test-decoder
+* Node.js/Browser (@redhotvengeance) - https://github.com/redhotvengeance/topl
 * Python (@uiri) - https://github.com/uiri/toml
 * Python (@marksteve) - https://github.com/marksteve/toml-ply
 * Ruby (@jm, @cespare) - https://gist.github.com/cespare/5052442


### PR DESCRIPTION
I have added support for `toml-test` to my Node.js/Browser TOML decoder, [topl](https://github.com/redhotvengeance/topl). This PR adds it to your list.

As of right now, `topl` fully passes the `toml-test` test suite, though only the tweaked one submitted in #13 (with JS-specific fixes in it).
