### PR TITLE
Add htoml to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ while using the tests in this repository. That's OK, but it's probably more
 work than necessary. Plus, I claim that `toml-test` outputs nice error 
 messages.
 
+* Haskell (@cies) - https://github.com/cies/htoml
 * Julia (@pygy) - https://github.com/pygy/TOML.jl
 * PHP (@yosymfony) - https://github.com/yosymfony/toml
 * Python (@f03lipe) - https://github.com/f03lipe/toml-python


### PR DESCRIPTION
I'll clarify why I only use the tests from your repository: this way I do not add a dependency on Go+toolchain.

Integrating your tests was very easy, I provided `ToBsJSON` instances for the used types (alongside the `ToJSON` which do not add typing info, and comply with the JSON translation found in the TOML spec). Your tests are compiled into the test suite that is managed by the "tasty" test framework giving me a standard interface to all tests (I also have a test suite on unit-level), and provides nice/uniform errors.

Thanks for your test suite! It helps a lot...

Side note: I think it is a little out of date with the current 0.3.1 spec, if I find some time I will send a PR for that.