### PR TITLE
Add tests asserting that newlines must appear after table names

### DIFF
--- a/tests/invalid/key-after-array.toml
+++ b/tests/invalid/key-after-array.toml
@@ -1,0 +1,1 @@
+[[agencies]] owner = "S Cjelli"

--- a/tests/invalid/key-after-table.toml
+++ b/tests/invalid/key-after-table.toml
@@ -1,0 +1,1 @@
+[history] guard = "sleeping"


### PR DESCRIPTION
I didn't see anything else testing for this, and I think it's a case worth testing for.
