### PR TITLE
avoid panics (and unreachable code) by moving the default case out of…

### DIFF
--- a/json.go
+++ b/json.go
@@ -16,11 +16,9 @@ func (r result) cmpJson(expected, test interface{}) result {
 		return r.cmpJsonMaps(e, test)
 	case []interface{}:
 		return r.cmpJsonArrays(e, test)
-	default:
-		return r.failedf("Key '%s' in expected output should be a map or a "+
-			"list of maps, but it's a %T.", r.key, expected)
 	}
-	panic("unreachable")
+	return r.failedf("Key '%s' in expected output should be a map or a "+
+		"list of maps, but it's a %T.", r.key, expected)
 }
 
 func (r result) cmpJsonMaps(

--- a/toml.go
+++ b/toml.go
@@ -30,10 +30,8 @@ func (r result) cmpToml(expected, test interface{}) result {
 		return r.cmpTomlMaps(e, test)
 	case []interface{}:
 		return r.cmpTomlArrays(e, test)
-	default:
-		return r.failedf("Unrecognized TOML structure: %T", expected)
 	}
-	panic("unreachable")
+	return r.failedf("Unrecognized TOML structure: %T", expected)
 }
 
 func (r result) cmpTomlMaps(


### PR DESCRIPTION
… the switch
