### PR TITLE
Add @iarna/toml to list of parsers that use the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,4 +233,4 @@ messages.
 * Julia (@pygy) - https://github.com/pygy/TOML.jl
 * PHP (@yosymfony) - https://github.com/yosymfony/toml
 * Python (@f03lipe) - https://github.com/f03lipe/toml-python
-
+* JavaScript (@iarna) - https://github.com/iarna/iarna-toml


### PR DESCRIPTION
I also produce https://shared.by.re-becca.org/misc/TOML-SPEC-SUPPORT.html, showing how the various actively developed JS parsers compare (which is why I use my own harness).