### PR TITLE
Fix link to TOML spec v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ format as the JSON that a TOML decoder should output.
 Version: v0.4.0 (in sync with TOML)
 
 Compatible with TOML version
-[v0.4.0](https://github.com/mojombo/toml/blob/master/versions/toml-v0.4.0.md)
+[v0.4.0](https://github.com/toml-lang/toml/blob/v0.4.0/versions/en/toml-v0.4.0.md)
 
 Dependencies: [Go](http://golang.org).
 


### PR DESCRIPTION
The repository for TOML has moved from https://github.com/mojombo/toml/ to https://github.com/toml-lang/toml/ . While GitHub transparently redirects to the latter, the link to the v0.4.0 spec has been broken, due to moving the spec document under `/versions/en/`.

This PR fixes the link. The new link points to the `v0.4.0` tag instead of `master`. This ensures that any future restructuring made in `master` doesn't affect our link again (unless someone recreates the `v0.4.0` tag, but that would be a poor decision.
