### PR TITLE
Add flag "-skip" to skip some tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/BurntSushi/toml-test
+
+go 1.11
+
+require github.com/BurntSushi/toml v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/results.go
+++ b/results.go
@@ -15,6 +15,7 @@ type result struct {
 	testName string
 	err      error
 	valid    bool
+	skipped  bool
 	failure  string
 	key      string
 }


### PR DESCRIPTION
Some tests on the TOML library are failing because this toml-test
library added some tests for stuff that's not supported yet. This should
be fixed, of course, but can't fix everything in a day and in the
meanwhile always having a certain subset of tests fail is somewhat
annoying, makes it easy to miss *new* test failures, and potentially
confusing for contributors.

So add a -skip flag to skip those tests until they're fixed.

Also add the test that's being run in the output:

	toml-test toml-test-decoder: 128 passed, 0 failed, 4 skipped
	toml-test toml-test-encoder:  61 passed, 0 failed, 6 skipped

Instead of just:

	128 passed, 0 failed, 4 skipped
	61 passed, 0 failed, 6 skipped

Also adds a go.mod, because otherwise it's hard/annoying to build this
in recent Go versions.