### PR TITLE
It fixes #74 Build depends on an apparently non-existent toml 0.3.2 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/BurntSushi/toml-test
 go 1.16
 
 require (
-	github.com/BurntSushi/toml v0.3.2-0.20210704081116-ccff24ee4463
+	github.com/BurntSushi/toml v0.3.2-0.20210624061728-01bfc69d1057
 	// no_term branch, which doesn't depend on x/term and x/sys
 	zgo.at/zli v0.0.0-20210619044753-e7020a328e59
 )
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.2-0.20210704081116-ccff24ee4463

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,5 @@
-github.com/BurntSushi/toml v0.3.2-0.20210614224209-34d990aa228d/go.mod h1:2QZjSXA5e+XyFeCAxxtL8Z4StYUsTquL8ODGPR3C3MA=
-github.com/BurntSushi/toml v0.3.2-0.20210621044154-20a94d639b8e/go.mod h1:t4zg8TkHfP16Vb3x4WKIw7zVYMit5QFtPEO8lOWxzTg=
-github.com/BurntSushi/toml v0.3.2-0.20210624061728-01bfc69d1057/go.mod h1:NMj2lD5LfMqcE0w8tnqOsH6944oaqpI1974lrIwerfE=
 github.com/BurntSushi/toml v0.3.2-0.20210704081116-ccff24ee4463 h1:CQCUjt8vUDGIEsctm4VWa1ibwc1kiGPy2TKzufTtJ7I=
 github.com/BurntSushi/toml v0.3.2-0.20210704081116-ccff24ee4463/go.mod h1:EkRrMiQQmfxK6kIldz3QbPlhmVkrjW1RDJUnbDqGYvc=
-github.com/BurntSushi/toml-test v0.1.1-0.20210620192437-de01089bbf76/go.mod h1:P/PrhmZ37t5llHfDuiouWXtFgqOoQ12SAh9j6EjrBR4=
-github.com/BurntSushi/toml-test v0.1.1-0.20210624055653-1f6389604dc6/go.mod h1:UAIt+Eo8itMZAAgImXkPGDMYsT1SsJkVdB5TuONl86A=
 github.com/BurntSushi/toml-test v0.1.1-0.20210704062846-269931e74e3f/go.mod h1:fnFWrIwqgHsEjVsW3RYCJmDo86oq9eiJ9u6bnqhtm2g=
 zgo.at/zli v0.0.0-20210619044753-e7020a328e59 h1:NId7flXh2TTB7XD/0/WBTuZ8L5mpNMCdYyqJ/VQIlFM=
 zgo.at/zli v0.0.0-20210619044753-e7020a328e59/go.mod h1:HLAc12TjNGT+VRXr76JnsNE3pbooQtwKWhX+RlDjQ2Y=


### PR DESCRIPTION
Build depends on an apparently non-existent toml 0.3.2 version.

If someone will use non-default Go proxy or direct only `GOPROXY=direct`,
the toml-test project will fail miserable.

It effects all projects around the world that uses the `toml` project
because it depends on the `toml-test` project.

This patch fixes it by setting correct SHA commit using
the `go mod tidy` command.