### PR TITLE
Test whitespace has higher precedence than date-time sep

### DIFF
--- a/tests/valid/comment/everywhere.json
+++ b/tests/valid/comment/everywhere.json
@@ -4,9 +4,13 @@
       "type": "integer",
       "value": "42"
     },
-    "d": {
+    "dt": {
       "type": "datetime",
       "value": "1979-05-27T07:32:12-07:00"
+    },
+    "d": {
+      "type": "date-local",
+      "value": "1979-05-27"
     },
     "more": [
       {

--- a/tests/valid/comment/everywhere.toml
+++ b/tests/valid/comment/everywhere.toml
@@ -24,4 +24,5 @@ more = [ # Comment
 ] # Hopefully not.
 
 # Make sure the space between the datetime and "#" isn't lexed.
-d = 1979-05-27T07:32:12-07:00  # c
+dt = 1979-05-27T07:32:12-07:00  # c
+d = 1979-05-27 # Comment


### PR DESCRIPTION
In TOML, the separator between a date and time can be ` `, `T`, `t`.  A
malformed parser might consume trailing ` ` and assume a time will be
following, erroring when its anything else.  We ran into this with
`toml_edit` (ordian/toml_edit#269) because our parser is LL(1) (no
backtracing) by default and we have to opt-in to LL(k) parsing
(backtrack when time isn't present).

Fixes #97