### PR TITLE
Add test for multiline strings with commas inside arrays

### DIFF
--- a/tests/valid/array/string-with-comma-2.json
+++ b/tests/valid/array/string-with-comma-2.json
@@ -1,0 +1,12 @@
+{
+  "title": [
+    {
+      "type": "string",
+      "value": "Client: XXXX,\nJob: XXXX"
+    },
+    {
+      "type": "string",
+      "value": "Code: XXXX"
+    }
+  ]
+}

--- a/tests/valid/array/string-with-comma-2.toml
+++ b/tests/valid/array/string-with-comma-2.toml
@@ -1,0 +1,5 @@
+title = [
+"""Client: XXXX,
+Job: XXXX""",
+"Code: XXXX"
+]


### PR DESCRIPTION
like regular strings, multiline strings with commas in them should not interfere with the parsing of arrays.

this test exercises an edge case in the python library `toml`: https://github.com/uiri/toml/issues/319

```
>>> toml.load(open('tests/valid/array/string-with-comma-2.toml'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/site-packages/toml/decoder.py", line 156, in load
    return loads(f.read(), _dict, decoder)
  File "/usr/lib/python3.10/site-packages/toml/decoder.py", line 511, in loads
    ret = decoder.load_line(line, currentlevel, multikey,
  File "/usr/lib/python3.10/site-packages/toml/decoder.py", line 767, in load_line
    k, koffset = self._load_line_multiline_str(pair[1])
  File "/usr/lib/python3.10/site-packages/toml/decoder.py", line 797, in _load_line_multiline_str
    while len(newp) > 1 and newp[-1][0] != '"' and newp[-1][0] != "'":
IndexError: string index out of range
```

