### PR TITLE
feat: tombi config.

### DIFF
--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,13 @@
+toml-version = "v1.1.0-preview"
+
+[files]
+exclude = ["tests/invalid/**"]
+
+[lint.rules]
+dotted-keys-out-of-order = "off"
+key-empty = "off"
+tables-out-of-order = "off"
+
+[[overrides]]
+files.include = ["**/*.toml"]
+format.enabled = false


### PR DESCRIPTION
I have added a [tombi](https://github.com/tombi-toml/tombi) config file so that lint errors can be obtained for the necessary parts, and without formatting existing files.
