### PR TITLE
`-script`: Place the -skip flags under the correct comments

### DIFF
--- a/cmd/toml-test/test.go
+++ b/cmd/toml-test/test.go
@@ -28,9 +28,9 @@ func cmdTest(f zli.Flags) {
 				if f.Encoder() {
 					failedEncoder = append(failedEncoder, "encoder/"+f.Path[6:])
 				} else if f.Invalid() {
-					failedValid = append(failedValid, f.Path)
-				} else {
 					failedInvalid = append(failedInvalid, f.Path)
+				} else {
+					failedValid = append(failedValid, f.Path)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #186 

If you think it would be a good idea to get rid of the `Failing "valid" tests`/`Failing "invalid" tests` comments altogether, I can do that too.